### PR TITLE
Fix title of README according to Markdown conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Welcome to Rails
+# Welcome to Rails
 
 Rails is a web-application framework that includes everything needed to
 create database-backed web applications according to the

--- a/railties/lib/rails/generators/rails/app/templates/README.md
+++ b/railties/lib/rails/generators/rails/app/templates/README.md
@@ -1,4 +1,4 @@
-## README
+# README
 
 This README would normally document whatever steps are necessary to get the
 application up and running.


### PR DESCRIPTION
The first heading in the README is indicated using a second level heading (`##`), which in my opinion is structural incorrect. Therefore, in this patch I changed the first heading to a first level heading (`#`).
