### PR TITLE
Remove log-related stuff from ActiveSupport::Dependencies

### DIFF
--- a/activerecord/test/cases/inheritance_test.rb
+++ b/activerecord/test/cases/inheritance_test.rb
@@ -441,12 +441,7 @@ class InheritanceComputeTypeTest < ActiveRecord::TestCase
   include InheritanceTestHelper
   fixtures :companies
 
-  def setup
-    ActiveSupport::Dependencies.log_activity = true
-  end
-
   teardown do
-    ActiveSupport::Dependencies.log_activity = false
     self.class.const_remove :FirmOnTheFly rescue nil
     Firm.const_remove :FirmOnTheFly rescue nil
   end

--- a/activesupport/lib/active_support/dependencies.rb
+++ b/activesupport/lib/active_support/dependencies.rb
@@ -88,15 +88,6 @@ module ActiveSupport #:nodoc:
     mattr_accessor :explicitly_unloadable_constants
     self.explicitly_unloadable_constants = []
 
-    # The logger is used for generating information on the action run-time
-    # (including benchmarking) if available. Can be set to nil for no logging.
-    # Compatible with both Ruby's own Logger and Log4r loggers.
-    mattr_accessor :logger
-
-    # Set to +true+ to enable logging of const_missing and file loads.
-    mattr_accessor :log_activity
-    self.log_activity = false
-
     # The WatchStack keeps a stack of the modules being watched as files are
     # loaded. If a file in the process of being loaded (parent.rb) triggers the
     # load of another file (child.rb) the stack will ensure that child.rb
@@ -352,7 +343,6 @@ module ActiveSupport #:nodoc:
     end
 
     def clear
-      log_call
       Dependencies.unload_interlock do
         loaded.clear
         loading.clear
@@ -361,7 +351,6 @@ module ActiveSupport #:nodoc:
     end
 
     def require_or_load(file_name, const_path = nil)
-      log_call file_name, const_path
       file_name = $` if file_name =~ /\.rb\z/
       expanded = File.expand_path(file_name)
       return if loaded.include?(expanded)
@@ -377,8 +366,6 @@ module ActiveSupport #:nodoc:
 
         begin
           if load?
-            log "loading #{file_name}"
-
             # Enable warnings if this file has not been loaded before and
             # warnings_on_first_load is set.
             load_args = ["#{file_name}.rb"]
@@ -390,7 +377,6 @@ module ActiveSupport #:nodoc:
               enable_warnings { result = load_file(*load_args) }
             end
           else
-            log "requiring #{file_name}"
             result = require file_name
           end
         rescue Exception
@@ -483,7 +469,6 @@ module ActiveSupport #:nodoc:
     # set of names that the file at +path+ may define. See
     # +loadable_constants_for_path+ for more details.
     def load_file(path, const_paths = loadable_constants_for_path(path))
-      log_call path, const_paths
       const_paths = [const_paths].compact unless const_paths.is_a? Array
       parent_paths = const_paths.collect { |const_path| const_path[/.*(?=::)/] || ::Object }
 
@@ -494,7 +479,6 @@ module ActiveSupport #:nodoc:
 
       autoloaded_constants.concat newly_defined_paths unless load_once_path?(path)
       autoloaded_constants.uniq!
-      log "loading #{path} defined #{newly_defined_paths * ', '}" unless newly_defined_paths.empty?
       result
     end
 
@@ -508,8 +492,6 @@ module ActiveSupport #:nodoc:
     # it is not possible to load the constant into from_mod, try its parent
     # module using +const_missing+.
     def load_missing_constant(from_mod, const_name)
-      log_call from_mod, const_name
-
       unless qualified_const_defined?(from_mod.name) && Inflector.constantize(from_mod.name).equal?(from_mod)
         raise ArgumentError, "A copy of #{from_mod} has been removed from the module tree but is still active!"
       end
@@ -673,8 +655,6 @@ module ActiveSupport #:nodoc:
     # exception, any new constants are regarded as being only partially defined
     # and will be removed immediately.
     def new_constants_in(*descs)
-      log_call(*descs)
-
       constant_watch_stack.watch_namespaces(descs)
       aborting = true
 
@@ -684,10 +664,8 @@ module ActiveSupport #:nodoc:
       ensure
         new_constants = constant_watch_stack.new_constants
 
-        log "New constants: #{new_constants * ', '}"
         return new_constants unless aborting
 
-        log "Error during loading, removing partially loaded constants "
         new_constants.each { |c| remove_constant(c) }.clear
       end
 
@@ -738,8 +716,6 @@ module ActiveSupport #:nodoc:
         parent = constantize(parent_name)
       end
 
-      log "removing constant #{const}"
-
       # In an autoloaded user.rb like this
       #
       #   autoload :Foo, 'foo'
@@ -760,7 +736,6 @@ module ActiveSupport #:nodoc:
         begin
           constantized = parent.const_get(to_remove, false)
         rescue NameError
-          log "the constant #{const} is not reachable anymore, skipping"
           return
         else
           constantized.before_remove_const if constantized.respond_to?(:before_remove_const)
@@ -770,27 +745,8 @@ module ActiveSupport #:nodoc:
       begin
         parent.instance_eval { remove_const to_remove }
       rescue NameError
-        log "the constant #{const} is not reachable anymore, skipping"
       end
     end
-
-    protected
-      def log_call(*args)
-        if log_activity?
-          arg_str = args.collect(&:inspect) * ', '
-          /in `([a-z_\?\!]+)'/ =~ caller(1).first
-          selector = $1 || '<unknown>'
-          log "called #{selector}(#{arg_str})"
-        end
-      end
-
-      def log(msg)
-        logger.debug "Dependencies: #{msg}" if log_activity?
-      end
-
-      def log_activity?
-        logger && log_activity
-      end
   end
 end
 

--- a/guides/source/active_support_core_extensions.md
+++ b/guides/source/active_support_core_extensions.md
@@ -632,8 +632,6 @@ module ActiveSupport
     mattr_accessor :load_once_paths
     mattr_accessor :autoloaded_constants
     mattr_accessor :explicitly_unloadable_constants
-    mattr_accessor :logger
-    mattr_accessor :log_activity
     mattr_accessor :constant_watch_stack
     mattr_accessor :constant_watch_stack_mutex
   end


### PR DESCRIPTION
### Summary

In this patch, all log-related stuff in `ActiveSupport::Dependencies` is removed because the logging is no longer useful. 
### Other Information

This task was assigned to us by @fxn. He indicated that the log-related stuff in `ActiveSupport::Dependencies` is no longer useful.

We, @ValMai, @vliegenthart, @basvijzendoorn, and myself, are glad to be of service to you :smile: 
